### PR TITLE
Migrate deprecate constant, remove unused constants.

### DIFF
--- a/custom_components/chargepoint/sensor.py
+++ b/custom_components/chargepoint/sensor.py
@@ -1,7 +1,7 @@
 """Sensor platform for ChargePoint."""
 import logging
 from dataclasses import dataclass
-from typing import Callable, Any, Optional, Union
+from typing import Callable, Optional, Union
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -10,23 +10,10 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_UNIT_SYSTEM_IMPERIAL,
-    LENGTH_KILOMETERS,
-    LENGTH_MILES,
-    PERCENTAGE,
-    PRESSURE_PSI,
-    CURRENCY_DOLLAR,
-    STATE_UNAVAILABLE,
-    STATE_ON,
-    STATE_OFF,
-    TIME_SECONDS,
-)
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.util.unit_system import UnitSystem
 
 from . import (
     ChargePointEntity,
@@ -181,7 +168,7 @@ CHARGER_SENSORS = [
         value=lambda entity: int(entity.session.charging_time / 1000)
         if entity.session
         else 0,
-        native_unit_of_measurement=TIME_SECONDS,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
     ),
     ChargePointSensorEntityDescription(
         key="session_power_kw",


### PR DESCRIPTION
- Remove a bunch of unused constants from the imports
- Switches TIME_SECONDS to using UnitOfTime so it's compatible with future HA core versions.

Resolves the logs:

```
2024-01-12 16:44:05.284 WARNING (MainThread) [homeassistant.const] LENGTH_KILOMETERS was used from chargepoint, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfLength.KILOMETERS instead, please create a bug report at https://github.com/mbillow/ha-chargepoint/issues
2024-01-12 16:44:05.294 WARNING (MainThread) [homeassistant.const] LENGTH_MILES was used from chargepoint, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfLength.MILES instead, please create a bug report at https://github.com/mbillow/ha-chargepoint/issues
2024-01-12 16:44:05.304 WARNING (MainThread) [homeassistant.const] PRESSURE_PSI was used from chargepoint, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfPressure.PSI instead, please create a bug report at https://github.com/mbillow/ha-chargepoint/issues
2024-01-12 16:44:05.313 WARNING (MainThread) [homeassistant.const] TIME_SECONDS was used from chargepoint, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTime.SECONDS instead, please create a bug report at https://github.com/mbillow/ha-chargepoint/issues
```

Fixes #36