### PR TITLE
Add support for setting amperage limit via Number entity

### DIFF
--- a/.docker/services/run
+++ b/.docker/services/run
@@ -5,7 +5,7 @@
 
 cd /config || bashio::exit.nok "Can't find config folder!"
 
-pip3 install python-chargepoint==1.8.0 || bashio::log.info "Failed to install python-chargepoint!"
+pip3 install git+https://github.com/conorbranagan/python-chargepoint@conor/add-set-amperage-limit-ha || bashio::log.info "Failed to install python-chargepoint!"
 
 # Enable Jemalloc for Home Assistant Core, unless disabled
 if [[ -z "${DISABLE_JEMALLOC+x}" ]]; then

--- a/.docker/services/run
+++ b/.docker/services/run
@@ -5,7 +5,7 @@
 
 cd /config || bashio::exit.nok "Can't find config folder!"
 
-pip3 install git+https://github.com/conorbranagan/python-chargepoint@conor/add-set-amperage-limit-ha || bashio::log.info "Failed to install python-chargepoint!"
+pip3 install python-chargepoint==1.9.2 || bashio::log.info "Failed to install python-chargepoint!"
 
 # Enable Jemalloc for Home Assistant Core, unless disabled
 if [[ -z "${DISABLE_JEMALLOC+x}" ]]; then

--- a/custom_components/chargepoint/const.py
+++ b/custom_components/chargepoint/const.py
@@ -11,7 +11,7 @@ ATTRIBUTION = "Data provided by https://www.chargepoint.com"
 ISSUE_URL = "https://github.com/mbillow/ha-chargepoint/issues"
 
 # Platforms
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]
 
 
 # Configuration and options

--- a/custom_components/chargepoint/const.py
+++ b/custom_components/chargepoint/const.py
@@ -11,7 +11,7 @@ ATTRIBUTION = "Data provided by https://www.chargepoint.com"
 ISSUE_URL = "https://github.com/mbillow/ha-chargepoint/issues"
 
 # Platforms
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.SELECT]
 
 
 # Configuration and options

--- a/custom_components/chargepoint/manifest.json
+++ b/custom_components/chargepoint/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/mbillow/ha-chargepoint/issues",
   "requirements": [
-      "python-chargepoint==1.8.0"
+      "python-chargepoint==1.9.0"
     ],
   "version": "0.6.0"
 }

--- a/custom_components/chargepoint/manifest.json
+++ b/custom_components/chargepoint/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/mbillow/ha-chargepoint/issues",
   "requirements": [
-      "python-chargepoint==1.9.0"
+      "python-chargepoint==1.9.2"
     ],
   "version": "0.6.0"
 }

--- a/custom_components/chargepoint/number.py
+++ b/custom_components/chargepoint/number.py
@@ -1,0 +1,146 @@
+import logging
+from datetime import datetime
+from typing import List, Tuple, Type
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.const import UnitOfElectricCurrent
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+
+from python_chargepoint.exceptions import ChargePointCommunicationException
+
+from . import ChargePointChargerEntity, ChargePointEntityRequiredKeysMixin
+from .const import (
+    DATA_CLIENT,
+    DATA_COORDINATOR,
+    DOMAIN,
+    ACCT_HOME_CRGS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+EXCEPTION_WARNING_MSG = "ChargePoint returned an exception, you might want to " + \
+                        "double check the amperage in the app."
+
+class ChargePointChargerNumberEntity(NumberEntity, ChargePointChargerEntity):
+    """Representation of a ChargePoint Charger Device Number."""
+
+    entity_description: NumberEntityDescription
+
+    def __init__(self, hass, client, coordinator, description, charger_id):
+        super().__init__(client, coordinator, charger_id)
+        self.hass = hass
+        self.entity_description = description
+
+        self._attr_name = f"{self.short_charger_model} {description.name_suffix}"
+        self._attr_unique_id = f"{charger_id}_{description.key}"
+
+    async def async_set_native_value(self, value: float) -> None:
+        pass
+
+
+class ChargePointChargerChargeLimitNumberEntity(ChargePointChargerNumberEntity):
+    """Specific entity for charge limit entity"""
+
+    def __init__(self, hass, client, coordinator, description, charger_id):
+        super().__init__(hass, client, coordinator, description, charger_id)
+        self._min_value = min(self.charger_status.possible_amperage_limits)
+        self._max_value = max(self.charger_status.possible_amperage_limits)
+        self._value = self.charger_status.amperage_limit
+
+    @property
+    def mode(self) -> NumberMode:
+        return NumberMode.AUTO
+    
+    @property
+    def native_max_value(self) -> float:
+        return self._max_value
+    
+    @property
+    def native_min_value(self) -> float:
+        return self._min_value
+    
+    @property
+    def native_step(self) -> float:
+        return 1
+    
+    @property
+    def native_value(self) -> float:
+        return self._value
+    
+    async def async_set_native_value(self, value: float) -> None:
+        if not self.charger_status.plugged_in:
+            self._attr_value = self.charger_status.amperage_limit
+            raise HomeAssistantError("Cannot set amperage if charger not plugged in!")
+
+        limit = int(value)
+        try:
+            _LOGGER.warn(
+                "Setting new ChargePoint amperage on Device ID: %s to %d", self.charger_id, limit
+            )
+            self._attr_available = False
+            await self.hass.async_add_executor_job(
+                self.client.set_amperage_limit, self.charger_id, limit,
+            )
+            self._attr_available = True
+            self._value = limit
+        except ChargePointCommunicationException:
+            _LOGGER.exception("Cannot set new amperage limit")
+            raise HomeAssistantError("Cannot set new amperage limit!")
+
+        await self.coordinator.async_request_refresh()
+
+
+class ChargePointChargerNumberEntityDescription(
+    NumberEntityDescription, ChargePointEntityRequiredKeysMixin
+):
+    """Number entity description with required fields"""
+
+    def __init__(self, **kwargs) -> None:
+        self.name_suffix = kwargs.pop("name_suffix")
+        super().__init__(**kwargs)
+
+
+CHARGER_NUMBERS: List[
+    Tuple[
+        Type[ChargePointChargerNumberEntity], ChargePointChargerNumberEntityDescription
+    ]
+] = [
+    (
+        ChargePointChargerChargeLimitNumberEntity,
+        ChargePointChargerNumberEntityDescription(
+            key="charging_amperage_limit",
+            name_suffix="Charging Amperage Limit",
+            device_class=NumberDeviceClass.CURRENT,
+            native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+            icon="mdi:lightning-bolt",
+        ),
+    )
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the numbers."""
+
+    client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+
+    entities: list[NumberEntity] = []
+
+    for charger_id in coordinator.data[ACCT_HOME_CRGS].keys():
+        for number_class, description in CHARGER_NUMBERS:
+            entities.append(
+                number_class(hass, client, coordinator, description, charger_id)
+            )
+
+    async_add_entities(entities)


### PR DESCRIPTION
# Changes

Adds support for setting the amperage limit on the ChargePoint charger using a `Select`. The charger must be plugged in for the new amperage to be reflected (and this appears to be the same behavior when it's set in the app).

The entity is provided the list of available values from the ChargePoint device.

# Testing

Used the provided docker-compose file to test this locally and validate it shows up as a new entity.

<img width="532" alt="Screenshot 2024-02-25 at 9 24 13 PM" src="https://github.com/mbillow/ha-chargepoint/assets/472446/3ecf1eed-0984-4116-97f7-907d9d19e237">


