### PR TITLE
Call file handling functions via async jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,7 @@ manually include this repository in HACS:
 1. If you haven't already installed HACS, follow [their instructions](https://hacs.xyz/docs/setup/prerequisites).
 2. Navigate to HACS.
 3. Choose "Integrations"
-4. Add this repository to your configuration.
-   1. Click the three dots in the upper right-hand corner.
-   2. Select "Custom repositories"
-   3. Enter `mbillow/ha-chargepoint` into the repository box.
-   4. Select the "Integration" type.
-   5. Click `Add`.
-5. Install the integration like you would [any other HACS addon](https://hacs.xyz/docs/navigation/overview).
+4. Install the integration like you would [any other HACS addon](https://hacs.xyz/docs/navigation/overview).
 
 ## Usage
 

--- a/custom_components/chargepoint/manifest.json
+++ b/custom_components/chargepoint/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
       "python-chargepoint==1.9.2"
     ],
-  "version": "0.7.0"
+  "version": "0.8.0"
 }


### PR DESCRIPTION
According to [new developer documentation](https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open), calls to synchronous / blocking operations need to be dispatched via async executor jobs. 

Fixes #44