### PR TITLE
Update README.md to fix broken HACS docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A cloud-polling Home Assistant component to expose ChargePoint Home Charger and 
 1. If you haven't already installed HACS, follow [their instructions](https://hacs.xyz/docs/setup/prerequisites).
 2. Navigate to HACS.
 3. Choose "Integrations"
-4. Install the integration like you would [any other HACS addon](https://hacs.xyz/docs/use/repositories/dashboard/).
+4. Install the integration like you would [any other HACS addon](https://hacs.xyz/docs/use/repositories/dashboard/). 
 
 ## Usage
 


### PR DESCRIPTION
Updated to show a link to the general HACS information page: https://hacs.xyz/docs/use/repositories/dashboard/ 


Fix: https://github.com/mbillow/ha-chargepoint/issues/64