### PR TITLE
Fix public station name missing secondary names (issue #75)

### DIFF
--- a/custom_components/chargepoint/__init__.py
+++ b/custom_components/chargepoint/__init__.py
@@ -167,25 +167,6 @@ def _backfill_station_name2(
         )
 
 
-async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Migrate old config entry versions."""
-    _LOGGER.debug("Migrating from version %s", config_entry.version)
-
-    if config_entry.version == 1:
-        chargers = [
-            {"name2": None, **c}
-            for c in config_entry.options.get(OPTION_PUBLIC_CHARGERS, [])
-        ]
-        hass.config_entries.async_update_entry(
-            config_entry,
-            options={**config_entry.options, OPTION_PUBLIC_CHARGERS: chargers},
-            version=2,
-        )
-
-    _LOGGER.debug("Migration to version %s complete", config_entry.version)
-    return True
-
-
 async def async_setup(hass: HomeAssistant, entry: ConfigEntry):
     """Disallow configuration via YAML"""
     return True

--- a/custom_components/chargepoint/__init__.py
+++ b/custom_components/chargepoint/__init__.py
@@ -151,18 +151,16 @@ def _backfill_station_name2(
     hass: HomeAssistant, entry: ConfigEntry, public_data: dict
 ) -> None:
     """Populate name2 for any tracked public station where it is still None."""
-    chargers = list(entry.options.get(OPTION_PUBLIC_CHARGERS, []))
     updated_chargers = []
-    names_updated = False
-    for charger in chargers:
-        charger = dict(charger)
+    changed = False
+    for charger in entry.options.get(OPTION_PUBLIC_CHARGERS, []):
         if charger.get("name2") is None:
             info = public_data.get(charger["id"])
             if info and len(info.name) > 1:
-                charger["name2"] = info.name[1]
-                names_updated = True
+                charger = {**charger, "name2": info.name[1]}
+                changed = True
         updated_chargers.append(charger)
-    if names_updated:
+    if changed:
         hass.config_entries.async_update_entry(
             entry,
             options={**entry.options, OPTION_PUBLIC_CHARGERS: updated_chargers},
@@ -174,13 +172,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
     if config_entry.version == 1:
-        new_options = dict(config_entry.options)
-        chargers = [dict(c) for c in new_options.get(OPTION_PUBLIC_CHARGERS, [])]
-        for charger in chargers:
-            charger.setdefault("name2", None)
-        new_options[OPTION_PUBLIC_CHARGERS] = chargers
+        chargers = [
+            {"name2": None, **c}
+            for c in config_entry.options.get(OPTION_PUBLIC_CHARGERS, [])
+        ]
         hass.config_entries.async_update_entry(
-            config_entry, options=new_options, version=2
+            config_entry,
+            options={**config_entry.options, OPTION_PUBLIC_CHARGERS: chargers},
+            version=2,
         )
 
     _LOGGER.debug("Migration to version %s complete", config_entry.version)

--- a/custom_components/chargepoint/__init__.py
+++ b/custom_components/chargepoint/__init__.py
@@ -147,6 +147,46 @@ def remove_session_token_from_disk(hass: HomeAssistant) -> None:
         os.remove(file)
 
 
+def _backfill_station_name2(
+    hass: HomeAssistant, entry: ConfigEntry, public_data: dict
+) -> None:
+    """Populate name2 for any tracked public station where it is still None."""
+    chargers = list(entry.options.get(OPTION_PUBLIC_CHARGERS, []))
+    updated_chargers = []
+    names_updated = False
+    for charger in chargers:
+        charger = dict(charger)
+        if charger.get("name2") is None:
+            info = public_data.get(charger["id"])
+            if info and len(info.name) > 1:
+                charger["name2"] = info.name[1]
+                names_updated = True
+        updated_chargers.append(charger)
+    if names_updated:
+        hass.config_entries.async_update_entry(
+            entry,
+            options={**entry.options, OPTION_PUBLIC_CHARGERS: updated_chargers},
+        )
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old config entry versions."""
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1:
+        new_options = dict(config_entry.options)
+        chargers = [dict(c) for c in new_options.get(OPTION_PUBLIC_CHARGERS, [])]
+        for charger in chargers:
+            charger.setdefault("name2", None)
+        new_options[OPTION_PUBLIC_CHARGERS] = chargers
+        hass.config_entries.async_update_entry(
+            config_entry, options=new_options, version=2
+        )
+
+    _LOGGER.debug("Migration to version %s complete", config_entry.version)
+    return True
+
+
 async def async_setup(hass: HomeAssistant, entry: ConfigEntry):
     """Disallow configuration via YAML"""
     return True
@@ -275,6 +315,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()
+
+    # Back-fill name2 for existing tracked public stations from live StationInfo data.
+    _backfill_station_name2(hass, entry, coordinator.data.get(ACCT_PUBLIC_STATIONS, {}))
 
     # Remove the old charging_session switch entity — replaced by Start/Stop buttons
     entity_registry = er.async_get(hass)

--- a/custom_components/chargepoint/binary_sensor.py
+++ b/custom_components/chargepoint/binary_sensor.py
@@ -71,7 +71,7 @@ async def async_setup_entry(
 
 def _station_device_info(device_id: int, info: Any) -> DeviceInfo:
     """Build DeviceInfo for a public station. Both entity types share the same device."""
-    station_name = info.name[0] if info.name else f"Station {device_id}"
+    station_name = " ".join(info.name) if info.name else f"Station {device_id}"
     address = ", ".join(filter(None, [info.address.address1, info.address.city]))
     if address:
         station_name = f"{station_name} ({address})"

--- a/custom_components/chargepoint/config_flow.py
+++ b/custom_components/chargepoint/config_flow.py
@@ -145,7 +145,7 @@ async def _login_with_token(
 class ChargePointFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for ChargePoint."""
 
-    VERSION = 2
+    VERSION = 1
     CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
 
     def __init__(self):

--- a/custom_components/chargepoint/config_flow.py
+++ b/custom_components/chargepoint/config_flow.py
@@ -145,7 +145,7 @@ async def _login_with_token(
 class ChargePointFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for ChargePoint."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
 
     def __init__(self):
@@ -417,6 +417,7 @@ class OptionsFlowHandler(OptionsFlow):
                     entry: dict[str, Any] = {
                         "id": sid,
                         "name": station.name1,
+                        "name2": station.name2 or None,
                         "address": addr,
                     }
                     detail = self._nearby_station_details.get(sid)
@@ -437,8 +438,9 @@ class OptionsFlowHandler(OptionsFlow):
         for s in self._nearby_stations:
             detail = self._nearby_station_details.get(s.device_id)
             summary = _connector_summary(detail) if detail else ""
+            combined_name = " ".join(filter(None, [s.name1, s.name2]))
             parts = filter(
-                None, [s.name1, s.address1, s.city, f"ID: {s.device_id}", summary]
+                None, [combined_name, s.address1, s.city, f"ID: {s.device_id}", summary]
             )
             options.append({"value": str(s.device_id), "label": " · ".join(parts)})
         pre_selected = [
@@ -489,9 +491,15 @@ class OptionsFlowHandler(OptionsFlow):
 
         options = []
         for c in chargers:
+            combined_name = " ".join(filter(None, [c["name"], c.get("name2")]))
             parts = filter(
                 None,
-                [c["name"], c.get("address"), f"ID: {c['id']}", c.get("connectors")],
+                [
+                    combined_name,
+                    c.get("address"),
+                    f"ID: {c['id']}",
+                    c.get("connectors"),
+                ],
             )
             options.append({"value": str(c["id"]), "label": " · ".join(parts)})
         # Pre-select all when there is only one so the user just hits Submit to confirm.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,11 +145,14 @@ def make_mock_station_info(*, available: bool = True) -> MagicMock:
     return info
 
 
-def make_mock_map_station(device_id: int = PUBLIC_STATION_ID) -> MagicMock:
+def make_mock_map_station(
+    device_id: int = PUBLIC_STATION_ID, name2: str | None = None
+) -> MagicMock:
     """Return a MagicMock shaped like MapStation."""
     station = MagicMock()
     station.device_id = device_id
     station.name1 = "Test Public Station"
+    station.name2 = name2
     station.address1 = "123 Test St"
     station.city = "Testville"
     station.station_status_v2 = "available"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -2,8 +2,20 @@
 
 from unittest.mock import AsyncMock, patch
 
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.chargepoint.const import (
+    CONF_USERNAME,
+    DOMAIN,
+    OPTION_PUBLIC_CHARGERS,
+)
+
 from .conftest import (
+    COULOMB_TOKEN,
     PUBLIC_STATION_ID,
+    USERNAME,
     get_entity_id,
     make_communication_error,
     make_mock_station_info,
@@ -140,3 +152,57 @@ async def test_station_fetch_error_skipped(
         hass, "binary_sensor", f"public_{PUBLIC_STATION_ID}_available"
     )
     assert entity_id is None
+
+
+# ---------------------------------------------------------------------------
+# Multi-name device naming
+# ---------------------------------------------------------------------------
+
+
+async def test_station_device_name_combines_multiple_names(hass, mock_client):
+    """When StationInfo.name has two entries, the device name joins them with a space."""
+    info = make_mock_station_info()
+    info.name = ["CLPCCD", "DO STATION 1"]
+    mock_client.get_station = AsyncMock(return_value=info)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: USERNAME, CONF_ACCESS_TOKEN: COULOMB_TOKEN},
+        options={
+            OPTION_PUBLIC_CHARGERS: [
+                {
+                    "id": PUBLIC_STATION_ID,
+                    "name": "CLPCCD",
+                    "name2": "DO STATION 1",
+                    "address": "123 Test St, Testville",
+                }
+            ]
+        },
+        entry_id="test_multi_name_entry",
+        version=2,
+    )
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        new_callable=AsyncMock,
+        return_value=mock_client,
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    identifier = (DOMAIN, f"public_{PUBLIC_STATION_ID}")
+    device = device_registry.async_get_device(identifiers={identifier})
+    assert device is not None
+    assert device.name == "CLPCCD DO STATION 1 (123 Test St, Testville)"
+
+
+async def test_station_device_name_single_name_unchanged(
+    hass, setup_integration_with_public_station
+):
+    """When StationInfo.name has only one entry, the device name is unchanged."""
+    device_registry = dr.async_get(hass)
+    identifier = (DOMAIN, f"public_{PUBLIC_STATION_ID}")
+    device = device_registry.async_get_device(identifiers={identifier})
+    assert device is not None
+    assert device.name == "Test Public Station (123 Test St, Testville)"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -179,7 +179,7 @@ async def test_station_device_name_combines_multiple_names(hass, mock_client):
             ]
         },
         entry_id="test_multi_name_entry",
-        version=2,
+        version=1,
     )
     with patch(
         "custom_components.chargepoint.ChargePoint.create",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -670,3 +670,74 @@ async def test_options_charger_ids_stored_as_ints(
 
     chargers = config_entry.options[OPTION_PUBLIC_CHARGERS]
     assert isinstance(chargers[0]["id"], int)
+
+
+# ---------------------------------------------------------------------------
+# name2 handling
+# ---------------------------------------------------------------------------
+
+
+async def test_options_add_charger_stores_name2_when_present(
+    hass, setup_integration, config_entry, mock_client
+):
+    """When a station has name2, it is stored alongside name in the config entry."""
+    mock_client.get_nearby_stations = AsyncMock(
+        return_value=[make_mock_map_station(name2="Port A")]
+    )
+    mock_client.get_station = AsyncMock(return_value=make_mock_station_info())
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "manage_chargers"}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "add_chargers"}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "location": {"latitude": 37.0, "longitude": -122.0, "radius": 200.0}
+        },
+    )
+    with patch("homeassistant.config_entries.ConfigEntries.async_reload"):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"charger_ids": [str(PUBLIC_STATION_ID)]},
+        )
+
+    chargers = config_entry.options[OPTION_PUBLIC_CHARGERS]
+    assert chargers[0]["name"] == "Test Public Station"
+    assert chargers[0]["name2"] == "Port A"
+
+
+async def test_options_add_charger_stores_name2_none_when_absent(
+    hass, setup_integration, config_entry, mock_client
+):
+    """When a station has no name2, None is stored so the key is always present."""
+    mock_client.get_nearby_stations = AsyncMock(
+        return_value=[make_mock_map_station(name2=None)]
+    )
+    mock_client.get_station = AsyncMock(return_value=make_mock_station_info())
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "manage_chargers"}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "add_chargers"}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "location": {"latitude": 37.0, "longitude": -122.0, "radius": 200.0}
+        },
+    )
+    with patch("homeassistant.config_entries.ConfigEntries.async_reload"):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"charger_ids": [str(PUBLIC_STATION_ID)]},
+        )
+
+    chargers = config_entry.options[OPTION_PUBLIC_CHARGERS]
+    assert chargers[0]["name"] == "Test Public Station"
+    assert chargers[0]["name2"] is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,15 +9,21 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.chargepoint.const import CONF_USERNAME, DOMAIN
+from custom_components.chargepoint.const import (
+    CONF_USERNAME,
+    DOMAIN,
+    OPTION_PUBLIC_CHARGERS,
+)
 
 from .conftest import (
     CHARGER_ID,
     COULOMB_TOKEN,
+    PUBLIC_STATION_ID,
     USERNAME,
     make_communication_error,
     make_datadome_captcha,
     make_invalid_session,
+    make_mock_station_info,
 )
 
 # ---------------------------------------------------------------------------
@@ -220,6 +226,136 @@ async def test_old_switch_cleanup_is_idempotent(
         await hass.async_block_till_done()
 
     assert config_entry.state == ConfigEntryState.LOADED
+
+
+# ---------------------------------------------------------------------------
+# v0 → v1 migration
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# v1 → v2 migration: name2 field
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_v1_to_v2_adds_name2_to_public_chargers(hass, mock_client):
+    """V1 → V2 migration adds name2: None to each tracked public charger entry."""
+    v1_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: USERNAME, CONF_ACCESS_TOKEN: COULOMB_TOKEN},
+        options={
+            OPTION_PUBLIC_CHARGERS: [
+                {"id": PUBLIC_STATION_ID, "name": "Old Station", "address": "1 St"},
+            ]
+        },
+        entry_id="test_v1_entry",
+        version=1,
+    )
+    mock_client.get_station = AsyncMock(return_value=make_mock_station_info())
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        new_callable=AsyncMock,
+        return_value=mock_client,
+    ):
+        v1_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(v1_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert v1_entry.version == 2
+    chargers = v1_entry.options[OPTION_PUBLIC_CHARGERS]
+    assert "name2" in chargers[0]
+
+
+async def test_migrate_v1_to_v2_with_no_public_chargers(hass, mock_client):
+    """V1 → V2 migration succeeds even when no public chargers are tracked."""
+    v1_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: USERNAME, CONF_ACCESS_TOKEN: COULOMB_TOKEN},
+        options={},
+        entry_id="test_v1_no_chargers",
+        version=1,
+    )
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        new_callable=AsyncMock,
+        return_value=mock_client,
+    ):
+        v1_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(v1_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert v1_entry.version == 2
+    assert v1_entry.state == ConfigEntryState.LOADED
+
+
+async def test_setup_backfills_name2_from_station_info(hass, mock_client):
+    """On startup, name2 is populated from StationInfo.name when it was None."""
+    info = make_mock_station_info()
+    info.name = ["Station Name", "Port A"]
+    mock_client.get_station = AsyncMock(return_value=info)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: USERNAME, CONF_ACCESS_TOKEN: COULOMB_TOKEN},
+        options={
+            OPTION_PUBLIC_CHARGERS: [
+                {
+                    "id": PUBLIC_STATION_ID,
+                    "name": "Station Name",
+                    "name2": None,
+                    "address": "123 Test St, Testville",
+                }
+            ]
+        },
+        entry_id="test_backfill_entry",
+        version=2,
+    )
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        new_callable=AsyncMock,
+        return_value=mock_client,
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    chargers = entry.options[OPTION_PUBLIC_CHARGERS]
+    assert chargers[0]["name2"] == "Port A"
+
+
+async def test_setup_does_not_update_when_name2_already_set(hass, mock_client):
+    """name2 is not overwritten when it is already populated."""
+    info = make_mock_station_info()
+    info.name = ["Station Name", "Port B"]
+    mock_client.get_station = AsyncMock(return_value=info)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: USERNAME, CONF_ACCESS_TOKEN: COULOMB_TOKEN},
+        options={
+            OPTION_PUBLIC_CHARGERS: [
+                {
+                    "id": PUBLIC_STATION_ID,
+                    "name": "Station Name",
+                    "name2": "Port A",
+                    "address": "123 Test St, Testville",
+                }
+            ]
+        },
+        entry_id="test_no_overwrite_entry",
+        version=2,
+    )
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        new_callable=AsyncMock,
+        return_value=mock_client,
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    chargers = entry.options[OPTION_PUBLIC_CHARGERS]
+    assert chargers[0]["name2"] == "Port A"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -229,67 +229,12 @@ async def test_old_switch_cleanup_is_idempotent(
 
 
 # ---------------------------------------------------------------------------
-# v0 → v1 migration
+# name2 back-fill
 # ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# v1 → v2 migration: name2 field
-# ---------------------------------------------------------------------------
-
-
-async def test_migrate_v1_to_v2_adds_name2_to_public_chargers(hass, mock_client):
-    """V1 → V2 migration adds name2: None to each tracked public charger entry."""
-    v1_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: USERNAME, CONF_ACCESS_TOKEN: COULOMB_TOKEN},
-        options={
-            OPTION_PUBLIC_CHARGERS: [
-                {"id": PUBLIC_STATION_ID, "name": "Old Station", "address": "1 St"},
-            ]
-        },
-        entry_id="test_v1_entry",
-        version=1,
-    )
-    mock_client.get_station = AsyncMock(return_value=make_mock_station_info())
-    with patch(
-        "custom_components.chargepoint.ChargePoint.create",
-        new_callable=AsyncMock,
-        return_value=mock_client,
-    ):
-        v1_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(v1_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert v1_entry.version == 2
-    chargers = v1_entry.options[OPTION_PUBLIC_CHARGERS]
-    assert "name2" in chargers[0]
-
-
-async def test_migrate_v1_to_v2_with_no_public_chargers(hass, mock_client):
-    """V1 → V2 migration succeeds even when no public chargers are tracked."""
-    v1_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: USERNAME, CONF_ACCESS_TOKEN: COULOMB_TOKEN},
-        options={},
-        entry_id="test_v1_no_chargers",
-        version=1,
-    )
-    with patch(
-        "custom_components.chargepoint.ChargePoint.create",
-        new_callable=AsyncMock,
-        return_value=mock_client,
-    ):
-        v1_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(v1_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert v1_entry.version == 2
-    assert v1_entry.state == ConfigEntryState.LOADED
 
 
 async def test_setup_backfills_name2_from_station_info(hass, mock_client):
-    """On startup, name2 is populated from StationInfo.name when it was None."""
+    """On startup, name2 is populated from StationInfo.name when the key is absent."""
     info = make_mock_station_info()
     info.name = ["Station Name", "Port A"]
     mock_client.get_station = AsyncMock(return_value=info)
@@ -302,13 +247,12 @@ async def test_setup_backfills_name2_from_station_info(hass, mock_client):
                 {
                     "id": PUBLIC_STATION_ID,
                     "name": "Station Name",
-                    "name2": None,
                     "address": "123 Test St, Testville",
                 }
             ]
         },
         entry_id="test_backfill_entry",
-        version=2,
+        version=1,
     )
     with patch(
         "custom_components.chargepoint.ChargePoint.create",
@@ -343,7 +287,7 @@ async def test_setup_does_not_update_when_name2_already_set(hass, mock_client):
             ]
         },
         entry_id="test_no_overwrite_entry",
-        version=2,
+        version=1,
     )
     with patch(
         "custom_components.chargepoint.ChargePoint.create",


### PR DESCRIPTION
Fixes #75

## What changed

ChargePoint's API returns two name fields per station — `name1` (the broad location name, e.g. "CLPCCD") and `name2` (the specific station name, e.g. "DO STATION 1"). The integration was only using `name1`, so all stations at the same location showed the same name in Home Assistant.

## How it's fixed

**Device display name** (`binary_sensor.py`): `StationInfo.name` is already a list containing both names. Changed `info.name[0]` to `" ".join(info.name)` so all name parts are joined with a space.

**Config flow UI labels** (`config_flow.py`): The add-station and remove-station selection screens now combine `name1` and `name2` into a single label. `name2` is also stored in the config entry options when a station is added so the remove screen can display the full name without hitting the API.

**Back-fill for existing stations** (`__init__.py`): On first startup after updating, `_backfill_station_name2` checks each tracked station and, if `name2` is missing, populates it from the live `StationInfo` response. No config entry migration is needed — `charger.get("name2")` returns `None` for both old entries (key absent) and new entries (`name2: None`), so existing installations are handled transparently.

## Tests

- Multi-name device naming (`test_binary_sensor.py`)
- `name2` stored on add, absent → `None` on add (`test_config_flow.py`)
- Back-fill populates `name2` from `StationInfo` on startup (`test_init.py`)
- Back-fill does not overwrite an already-set `name2` (`test_init.py`)