### PR TITLE
Fix coordinator error handling to prevent integration crashes on API failures

### DIFF
--- a/custom_components/chargepoint/__init__.py
+++ b/custom_components/chargepoint/__init__.py
@@ -170,28 +170,29 @@ def _backfill_station_name2(
 async def _async_fetch_home_charger_data(
     client: ChargePoint, charger: int
 ) -> dict[str, Any]:
-    """Fetch all data for a single home charger, tolerating partial failures."""
-    hcrg_status: Optional[HomeChargerStatus] = None
-    hcrg_tech_info: Optional[HomeChargerTechnicalInfo] = None
-    hcrg_config: Optional[HomeChargerConfiguration] = None
+    """Fetch all data for a single home charger concurrently, tolerating partial failures."""
 
-    try:
-        hcrg_status = await client.get_home_charger_status(charger)
-    except CommunicationError:
-        _LOGGER.warning(
+    async def _safe_fetch(coro, warning_msg):
+        try:
+            return await coro
+        except CommunicationError:
+            _LOGGER.warning(warning_msg, charger)
+            return None
+
+    hcrg_status, hcrg_tech_info, hcrg_config = await asyncio.gather(
+        _safe_fetch(
+            client.get_home_charger_status(charger),
             "Failed to get status for charger %s, charger will be marked unavailable",
-            charger,
-        )
-
-    try:
-        hcrg_tech_info = await client.get_home_charger_technical_info(charger)
-    except CommunicationError:
-        _LOGGER.warning("Failed to get technical info for charger %s", charger)
-
-    try:
-        hcrg_config = await client.get_home_charger_config(charger)
-    except CommunicationError:
-        _LOGGER.warning("Failed to get configuration for charger %s", charger)
+        ),
+        _safe_fetch(
+            client.get_home_charger_technical_info(charger),
+            "Failed to get technical info for charger %s",
+        ),
+        _safe_fetch(
+            client.get_home_charger_config(charger),
+            "Failed to get configuration for charger %s",
+        ),
+    )
 
     return {
         ACCT_CHARGER_STATUS: hcrg_status,
@@ -242,10 +243,13 @@ async def _async_coordinator_update(
             )
 
         home_chargers: list = await client.get_home_chargers()
-        for charger in home_chargers:
-            data[ACCT_HOME_CRGS][charger] = await _async_fetch_home_charger_data(
-                client, charger
+        results = await asyncio.gather(
+            *(
+                _async_fetch_home_charger_data(client, charger)
+                for charger in home_chargers
             )
+        )
+        data[ACCT_HOME_CRGS] = dict(zip(home_chargers, results))
 
         data[ACCT_PUBLIC_STATIONS] = await _fetch_public_stations(client, entry.options)
 
@@ -436,8 +440,8 @@ class ChargePointChargerEntity(CoordinatorEntity):
         """Return True only when coordinator has fresh status data for this charger."""
         if not super().available:
             return False
-        charger_data = (
-            (self.coordinator.data or {}).get(ACCT_HOME_CRGS, {}).get(self.charger_id)
+        charger_data = self.coordinator.data.get(ACCT_HOME_CRGS, {}).get(
+            self.charger_id
         )
         return (
             charger_data is not None

--- a/custom_components/chargepoint/__init__.py
+++ b/custom_components/chargepoint/__init__.py
@@ -226,30 +226,62 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             _LOGGER.debug("Account information: %s", account)
             data[ACCT_INFO] = account
 
-            crg_status: Optional[UserChargingStatus] = (
-                await client.get_user_charging_status()
-            )
-            _LOGGER.debug("User charging status: %s", crg_status)
-            data[ACCT_CRG_STATUS] = crg_status
-
-            if crg_status:
-                crg_session: ChargingSession = await client.get_charging_session(
-                    crg_status.session_id
+            try:
+                crg_status: Optional[UserChargingStatus] = (
+                    await client.get_user_charging_status()
                 )
-                _LOGGER.debug("Charging session: %s", crg_session)
-                data[ACCT_SESSION] = crg_session
+                _LOGGER.debug("User charging status: %s", crg_status)
+                data[ACCT_CRG_STATUS] = crg_status
+
+                if crg_status:
+                    try:
+                        crg_session: ChargingSession = await client.get_charging_session(
+                            crg_status.session_id
+                        )
+                        _LOGGER.debug("Charging session: %s", crg_session)
+                        data[ACCT_SESSION] = crg_session
+                    except CommunicationError:
+                        _LOGGER.warning(
+                            "Failed to fetch active charging session details, "
+                            "session data will be unavailable this update"
+                        )
+            except CommunicationError:
+                _LOGGER.warning(
+                    "Failed to fetch user charging status, "
+                    "session data will be unavailable this update"
+                )
 
             home_chargers: list = await client.get_home_chargers()
             for charger in home_chargers:
-                hcrg_status: HomeChargerStatus = await client.get_home_charger_status(
-                    charger
-                )
-                hcrg_tech_info: HomeChargerTechnicalInfo = (
-                    await client.get_home_charger_technical_info(charger)
-                )
-                hcrg_config: HomeChargerConfiguration = (
-                    await client.get_home_charger_config(charger)
-                )
+                hcrg_status: Optional[HomeChargerStatus] = None
+                hcrg_tech_info: Optional[HomeChargerTechnicalInfo] = None
+                hcrg_config: Optional[HomeChargerConfiguration] = None
+
+                try:
+                    hcrg_status = await client.get_home_charger_status(charger)
+                except CommunicationError:
+                    _LOGGER.warning(
+                        "Failed to get status for charger %s, "
+                        "charger will be marked unavailable",
+                        charger,
+                    )
+
+                try:
+                    hcrg_tech_info = await client.get_home_charger_technical_info(
+                        charger
+                    )
+                except CommunicationError:
+                    _LOGGER.warning(
+                        "Failed to get technical info for charger %s", charger
+                    )
+
+                try:
+                    hcrg_config = await client.get_home_charger_config(charger)
+                except CommunicationError:
+                    _LOGGER.warning(
+                        "Failed to get configuration for charger %s", charger
+                    )
+
                 data[ACCT_HOME_CRGS][charger] = {
                     ACCT_CHARGER_STATUS: hcrg_status,
                     ACCT_CHARGER_TECH_INFO: hcrg_tech_info,
@@ -391,6 +423,19 @@ class ChargePointChargerEntity(CoordinatorEntity):
             name=device_name,
             sw_version=self.technical_info.software_version,
             configuration_url="https://www.chargepoint.com",
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True only when coordinator has fresh status data for this charger."""
+        if not super().available:
+            return False
+        charger_data = (self.coordinator.data or {}).get(ACCT_HOME_CRGS, {}).get(
+            self.charger_id
+        )
+        return (
+            charger_data is not None
+            and charger_data.get(ACCT_CHARGER_STATUS) is not None
         )
 
     @property

--- a/custom_components/chargepoint/__init__.py
+++ b/custom_components/chargepoint/__init__.py
@@ -167,6 +167,100 @@ def _backfill_station_name2(
         )
 
 
+async def _async_fetch_home_charger_data(
+    client: ChargePoint, charger: int
+) -> dict[str, Any]:
+    """Fetch all data for a single home charger, tolerating partial failures."""
+    hcrg_status: Optional[HomeChargerStatus] = None
+    hcrg_tech_info: Optional[HomeChargerTechnicalInfo] = None
+    hcrg_config: Optional[HomeChargerConfiguration] = None
+
+    try:
+        hcrg_status = await client.get_home_charger_status(charger)
+    except CommunicationError:
+        _LOGGER.warning(
+            "Failed to get status for charger %s, charger will be marked unavailable",
+            charger,
+        )
+
+    try:
+        hcrg_tech_info = await client.get_home_charger_technical_info(charger)
+    except CommunicationError:
+        _LOGGER.warning("Failed to get technical info for charger %s", charger)
+
+    try:
+        hcrg_config = await client.get_home_charger_config(charger)
+    except CommunicationError:
+        _LOGGER.warning("Failed to get configuration for charger %s", charger)
+
+    return {
+        ACCT_CHARGER_STATUS: hcrg_status,
+        ACCT_CHARGER_TECH_INFO: hcrg_tech_info,
+        ACCT_CHARGER_CONFIG: hcrg_config,
+    }
+
+
+async def _async_coordinator_update(
+    client: ChargePoint, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Fetch all ChargePoint data for one coordinator update cycle."""
+    data: dict[str, Any] = {
+        ACCT_INFO: None,
+        ACCT_CRG_STATUS: None,
+        ACCT_SESSION: None,
+        ACCT_HOME_CRGS: {},
+        ACCT_PUBLIC_STATIONS: {},
+    }
+    try:
+        account: Account = await client.get_account()
+        _LOGGER.debug("Account information: %s", account)
+        data[ACCT_INFO] = account
+
+        try:
+            crg_status: Optional[UserChargingStatus] = (
+                await client.get_user_charging_status()
+            )
+            _LOGGER.debug("User charging status: %s", crg_status)
+            data[ACCT_CRG_STATUS] = crg_status
+
+            if crg_status:
+                try:
+                    crg_session: ChargingSession = await client.get_charging_session(
+                        crg_status.session_id
+                    )
+                    _LOGGER.debug("Charging session: %s", crg_session)
+                    data[ACCT_SESSION] = crg_session
+                except CommunicationError:
+                    _LOGGER.warning(
+                        "Failed to fetch active charging session details, "
+                        "session data will be unavailable this update"
+                    )
+        except CommunicationError:
+            _LOGGER.warning(
+                "Failed to fetch user charging status, "
+                "session data will be unavailable this update"
+            )
+
+        home_chargers: list = await client.get_home_chargers()
+        for charger in home_chargers:
+            data[ACCT_HOME_CRGS][charger] = await _async_fetch_home_charger_data(
+                client, charger
+            )
+
+        data[ACCT_PUBLIC_STATIONS] = await _fetch_public_stations(client, entry.options)
+
+        return data
+    except (DatadomeCaptcha, InvalidSession) as exc:
+        _LOGGER.error(
+            "ChargePoint session is invalid or blocked by Datadome captcha. "
+            "Reauthentication required."
+        )
+        raise ConfigEntryAuthFailed(exc) from exc
+    except CommunicationError as err:
+        _LOGGER.error("Failed to update ChargePoint State")
+        raise UpdateFailed from err
+
+
 async def async_setup(hass: HomeAssistant, entry: ConfigEntry):
     """Disallow configuration via YAML"""
     return True
@@ -213,95 +307,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
 
     async def async_update_data():
-        """Fetch data from ChargePoint API"""
-        data: dict[str, Any] = {
-            ACCT_INFO: None,
-            ACCT_CRG_STATUS: None,
-            ACCT_SESSION: None,
-            ACCT_HOME_CRGS: {},
-            ACCT_PUBLIC_STATIONS: {},
-        }
-        try:
-            account: Account = await client.get_account()
-            _LOGGER.debug("Account information: %s", account)
-            data[ACCT_INFO] = account
-
-            try:
-                crg_status: Optional[UserChargingStatus] = (
-                    await client.get_user_charging_status()
-                )
-                _LOGGER.debug("User charging status: %s", crg_status)
-                data[ACCT_CRG_STATUS] = crg_status
-
-                if crg_status:
-                    try:
-                        crg_session: ChargingSession = await client.get_charging_session(
-                            crg_status.session_id
-                        )
-                        _LOGGER.debug("Charging session: %s", crg_session)
-                        data[ACCT_SESSION] = crg_session
-                    except CommunicationError:
-                        _LOGGER.warning(
-                            "Failed to fetch active charging session details, "
-                            "session data will be unavailable this update"
-                        )
-            except CommunicationError:
-                _LOGGER.warning(
-                    "Failed to fetch user charging status, "
-                    "session data will be unavailable this update"
-                )
-
-            home_chargers: list = await client.get_home_chargers()
-            for charger in home_chargers:
-                hcrg_status: Optional[HomeChargerStatus] = None
-                hcrg_tech_info: Optional[HomeChargerTechnicalInfo] = None
-                hcrg_config: Optional[HomeChargerConfiguration] = None
-
-                try:
-                    hcrg_status = await client.get_home_charger_status(charger)
-                except CommunicationError:
-                    _LOGGER.warning(
-                        "Failed to get status for charger %s, "
-                        "charger will be marked unavailable",
-                        charger,
-                    )
-
-                try:
-                    hcrg_tech_info = await client.get_home_charger_technical_info(
-                        charger
-                    )
-                except CommunicationError:
-                    _LOGGER.warning(
-                        "Failed to get technical info for charger %s", charger
-                    )
-
-                try:
-                    hcrg_config = await client.get_home_charger_config(charger)
-                except CommunicationError:
-                    _LOGGER.warning(
-                        "Failed to get configuration for charger %s", charger
-                    )
-
-                data[ACCT_HOME_CRGS][charger] = {
-                    ACCT_CHARGER_STATUS: hcrg_status,
-                    ACCT_CHARGER_TECH_INFO: hcrg_tech_info,
-                    ACCT_CHARGER_CONFIG: hcrg_config,
-                }
-
-            data[ACCT_PUBLIC_STATIONS] = await _fetch_public_stations(
-                client, entry.options
-            )
-
-            return data
-        except (DatadomeCaptcha, InvalidSession) as exc:
-            _LOGGER.error(
-                "ChargePoint session is invalid or blocked by Datadome captcha. "
-                "Reauthentication required."
-            )
-            raise ConfigEntryAuthFailed(exc) from exc
-        except CommunicationError as err:
-            _LOGGER.error("Failed to update ChargePoint State")
-            raise UpdateFailed from err
+        return await _async_coordinator_update(client, entry)
 
     poll_interval = entry.options.get(OPTION_POLL_INTERVAL, POLL_INTERVAL_DEFAULT)
     if poll_interval not in POLL_INTERVAL_OPTIONS.values():
@@ -430,8 +436,8 @@ class ChargePointChargerEntity(CoordinatorEntity):
         """Return True only when coordinator has fresh status data for this charger."""
         if not super().available:
             return False
-        charger_data = (self.coordinator.data or {}).get(ACCT_HOME_CRGS, {}).get(
-            self.charger_id
+        charger_data = (
+            (self.coordinator.data or {}).get(ACCT_HOME_CRGS, {}).get(self.charger_id)
         )
         return (
             charger_data is not None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -155,6 +155,74 @@ async def test_coordinator_communication_error_raises_update_failed(
         await coordinator._async_update_data()
 
 
+async def test_coordinator_charger_config_error_does_not_fail_update(
+    hass, setup_integration, mock_client
+):
+    """A 500 from get_home_charger_config should not crash the coordinator update."""
+    from custom_components.chargepoint.const import (
+        ACCT_CHARGER_CONFIG,
+        ACCT_CHARGER_STATUS,
+        ACCT_HOME_CRGS,
+        DATA_COORDINATOR,
+    )
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id][DATA_COORDINATOR]
+    mock_client.get_home_charger_config = AsyncMock(
+        side_effect=make_communication_error()
+    )
+
+    data = await coordinator._async_update_data()
+
+    # Update should succeed and charger status should still be present
+    assert CHARGER_ID in data[ACCT_HOME_CRGS]
+    assert data[ACCT_HOME_CRGS][CHARGER_ID][ACCT_CHARGER_STATUS] is not None
+    # Config should be None since the call failed
+    assert data[ACCT_HOME_CRGS][CHARGER_ID][ACCT_CHARGER_CONFIG] is None
+
+
+async def test_coordinator_charger_status_error_sets_status_none(
+    hass, setup_integration, mock_client
+):
+    """A failed get_home_charger_status stores None so the entity goes unavailable."""
+    from custom_components.chargepoint.const import (
+        ACCT_CHARGER_STATUS,
+        ACCT_HOME_CRGS,
+        DATA_COORDINATOR,
+    )
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id][DATA_COORDINATOR]
+    mock_client.get_home_charger_status = AsyncMock(
+        side_effect=make_communication_error()
+    )
+
+    data = await coordinator._async_update_data()
+
+    assert CHARGER_ID in data[ACCT_HOME_CRGS]
+    assert data[ACCT_HOME_CRGS][CHARGER_ID][ACCT_CHARGER_STATUS] is None
+
+
+async def test_coordinator_charging_status_error_does_not_fail_update(
+    hass, setup_integration, mock_client
+):
+    """A failed get_user_charging_status should not crash the coordinator update."""
+    from custom_components.chargepoint.const import (
+        ACCT_CRG_STATUS,
+        ACCT_HOME_CRGS,
+        DATA_COORDINATOR,
+    )
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id][DATA_COORDINATOR]
+    mock_client.get_user_charging_status = AsyncMock(
+        side_effect=make_communication_error()
+    )
+
+    data = await coordinator._async_update_data()
+
+    # Charging status stays None but home charger data is still populated
+    assert data[ACCT_CRG_STATUS] is None
+    assert CHARGER_ID in data[ACCT_HOME_CRGS]
+
+
 # ---------------------------------------------------------------------------
 # async_unload_entry
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,7 +2,14 @@
 
 from unittest.mock import AsyncMock, patch
 
-from .conftest import CHARGER_ID, USER_ID, get_entity_id, make_mock_charger_status
+from custom_components.chargepoint.const import (
+    ACCT_CHARGER_STATUS,
+    ACCT_HOME_CRGS,
+    DOMAIN,
+    DATA_COORDINATOR,
+)
+
+from .conftest import CHARGER_ID, USER_ID, get_entity_id, make_communication_error, make_mock_charger_status
 
 # ---------------------------------------------------------------------------
 # Account sensors
@@ -139,3 +146,52 @@ async def test_miles_per_hour_active_session(hass, setup_integration_with_sessio
 async def test_charge_cost_active_session(hass, setup_integration_with_session):
     entity_id = get_entity_id(hass, "sensor", f"{CHARGER_ID}_session_cost")
     assert hass.states.get(entity_id).state == "1.50"
+
+
+# ---------------------------------------------------------------------------
+# Charger entity availability
+# ---------------------------------------------------------------------------
+
+
+async def test_charger_entity_unavailable_when_status_is_none(
+    hass, setup_integration, mock_client
+):
+    """When charger status fetch fails, charger entities become unavailable."""
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id][DATA_COORDINATOR]
+
+    # Simulate a failed status fetch by patching the coordinator data directly
+    coordinator.data[ACCT_HOME_CRGS][CHARGER_ID][ACCT_CHARGER_STATUS] = None
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    entity_id = get_entity_id(hass, "sensor", f"{CHARGER_ID}_charging_status")
+    state = hass.states.get(entity_id)
+    assert state.state == "unavailable"
+
+
+async def test_charger_entity_available_after_status_recovers(
+    hass, setup_integration, mock_client
+):
+    """Charger entities recover availability when the API starts responding again."""
+    from .conftest import make_mock_charger_status
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id][DATA_COORDINATOR]
+
+    # First fail the status fetch
+    mock_client.get_home_charger_status = AsyncMock(
+        side_effect=make_communication_error()
+    )
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    entity_id = get_entity_id(hass, "sensor", f"{CHARGER_ID}_charging_status")
+    assert hass.states.get(entity_id).state == "unavailable"
+
+    # Then recover
+    mock_client.get_home_charger_status = AsyncMock(
+        return_value=make_mock_charger_status()
+    )
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state != "unavailable"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,11 +5,17 @@ from unittest.mock import AsyncMock, patch
 from custom_components.chargepoint.const import (
     ACCT_CHARGER_STATUS,
     ACCT_HOME_CRGS,
-    DOMAIN,
     DATA_COORDINATOR,
+    DOMAIN,
 )
 
-from .conftest import CHARGER_ID, USER_ID, get_entity_id, make_communication_error, make_mock_charger_status
+from .conftest import (
+    CHARGER_ID,
+    USER_ID,
+    get_entity_id,
+    make_communication_error,
+    make_mock_charger_status,
+)
 
 # ---------------------------------------------------------------------------
 # Account sensors
@@ -159,9 +165,17 @@ async def test_charger_entity_unavailable_when_status_is_none(
     """When charger status fetch fails, charger entities become unavailable."""
     coordinator = hass.data[DOMAIN][setup_integration.entry_id][DATA_COORDINATOR]
 
-    # Simulate a failed status fetch by patching the coordinator data directly
-    coordinator.data[ACCT_HOME_CRGS][CHARGER_ID][ACCT_CHARGER_STATUS] = None
-    await coordinator.async_refresh()
+    # Push coordinator data with None status without triggering a re-fetch
+    updated_data = {
+        **coordinator.data,
+        ACCT_HOME_CRGS: {
+            CHARGER_ID: {
+                **coordinator.data[ACCT_HOME_CRGS][CHARGER_ID],
+                ACCT_CHARGER_STATUS: None,
+            }
+        },
+    }
+    coordinator.async_set_updated_data(updated_data)
     await hass.async_block_till_done()
 
     entity_id = get_entity_id(hass, "sensor", f"{CHARGER_ID}_charging_status")


### PR DESCRIPTION
Per-charger API calls (status, tech info, config) are now wrapped individually
so a single 500 error from ChargePoint does not fail the entire coordinator
update cycle. Non-critical calls (charging status, session details) are also
wrapped so transient errors don't cascade. ChargePointChargerEntity gains an
`available` property that marks charger entities unavailable when their status
data is None, rather than crashing with an AttributeError.

Part of #79

https://claude.ai/code/session_011e1n8pTHf2S3vFJBWcTXPY