### PR TITLE
Fix session expiry: use private session and auto-recover from RuntimeError

### DIFF
--- a/custom_components/chargepoint/__init__.py
+++ b/custom_components/chargepoint/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -332,7 +331,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         client: ChargePoint = await ChargePoint.create(
             username,
             coulomb_token=coulomb_token,
-            session=async_get_clientsession(hass),
         )
     except DatadomeCaptcha:
         _LOGGER.error(
@@ -353,7 +351,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
 
     async def async_update_data():
-        data = await _async_coordinator_update(client, entry)
+        nonlocal client
+        try:
+            data = await _async_coordinator_update(client, entry)
+        except RuntimeError:
+            # The library raises RuntimeError("Must login to use ChargePoint API")
+            # when the coulomb_sess cookie has expired from the aiohttp cookie jar.
+            # Attempt to recover automatically using the stored token before
+            # falling back to a full reauthentication prompt.
+            _LOGGER.warning(
+                "ChargePoint session has expired; attempting automatic re-login"
+            )
+            stored_token: str = entry.data.get(CONF_ACCESS_TOKEN) or ""
+            try:
+                await client.close()
+                client = await ChargePoint.create(
+                    username,
+                    coulomb_token=stored_token,
+                )
+                hass.data[DOMAIN][entry.entry_id][DATA_CLIENT] = client
+            except (DatadomeCaptcha, InvalidSession) as exc:
+                _LOGGER.error(
+                    "Automatic re-login failed; manual reauthentication required"
+                )
+                raise ConfigEntryAuthFailed(exc) from exc
+            except CommunicationError as exc:
+                raise UpdateFailed from exc
+            data = await _async_coordinator_update(client, entry)
+
         current_token = entry.data.get(CONF_ACCESS_TOKEN)
         fresh_token = client.coulomb_token
         if fresh_token and fresh_token != current_token:

--- a/custom_components/chargepoint/__init__.py
+++ b/custom_components/chargepoint/__init__.py
@@ -242,6 +242,24 @@ async def _async_fetch_home_charger_data(
     }
 
 
+async def _async_recreate_client(
+    username: str, stored_token: str, old_client: ChargePoint
+) -> ChargePoint:
+    """Close a stale client and create a fresh one using the stored token.
+
+    Raises ConfigEntryAuthFailed if the token is invalid or blocked by captcha.
+    Raises UpdateFailed on communication errors.
+    """
+    await old_client.close()
+    try:
+        return await ChargePoint.create(username, coulomb_token=stored_token)
+    except (DatadomeCaptcha, InvalidSession) as exc:
+        _LOGGER.error("Automatic re-login failed; manual reauthentication required")
+        raise ConfigEntryAuthFailed(exc) from exc
+    except CommunicationError as exc:
+        raise UpdateFailed from exc
+
+
 async def _async_coordinator_update(
     client: ChargePoint, entry: ConfigEntry
 ) -> dict[str, Any]:
@@ -363,20 +381,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 "ChargePoint session has expired; attempting automatic re-login"
             )
             stored_token: str = entry.data.get(CONF_ACCESS_TOKEN) or ""
-            try:
-                await client.close()
-                client = await ChargePoint.create(
-                    username,
-                    coulomb_token=stored_token,
-                )
-                hass.data[DOMAIN][entry.entry_id][DATA_CLIENT] = client
-            except (DatadomeCaptcha, InvalidSession) as exc:
-                _LOGGER.error(
-                    "Automatic re-login failed; manual reauthentication required"
-                )
-                raise ConfigEntryAuthFailed(exc) from exc
-            except CommunicationError as exc:
-                raise UpdateFailed from exc
+            client = await _async_recreate_client(username, stored_token, client)
+            hass.data[DOMAIN][entry.entry_id][DATA_CLIENT] = client
             data = await _async_coordinator_update(client, entry)
 
         current_token = entry.data.get(CONF_ACCESS_TOKEN)

--- a/custom_components/chargepoint/const.py
+++ b/custom_components/chargepoint/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import Platform
 NAME = "ChargePoint"
 DOMAIN = "chargepoint"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "1.3.0"
+VERSION = "1.3.1"
 ATTRIBUTION = "Data provided by https://www.chargepoint.com"
 ISSUE_URL = "https://github.com/mbillow/ha-chargepoint/issues"
 

--- a/custom_components/chargepoint/manifest.json
+++ b/custom_components/chargepoint/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
       "python-chargepoint>=2.3.2"
     ],
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,9 +215,8 @@ def make_datadome_captcha(
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def mock_client():
-    """A fully-mocked ChargePoint client with no active session."""
+def make_mock_client():
+    """Build a fully-mocked ChargePoint client with no active session."""
     client = MagicMock()
     client.coulomb_token = COULOMB_TOKEN
     client.global_config.default_currency.symbol = "USD"
@@ -240,6 +239,12 @@ def mock_client():
     client.start_charging_session = AsyncMock(return_value=make_mock_session())
     client.close = AsyncMock()
     return client
+
+
+@pytest.fixture
+def mock_client():
+    """A fully-mocked ChargePoint client with no active session."""
+    return make_mock_client()
 
 
 @pytest.fixture

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,6 +23,7 @@ from .conftest import (
     make_communication_error,
     make_datadome_captcha,
     make_invalid_session,
+    make_mock_client,
     make_mock_station_info,
 )
 
@@ -153,6 +154,74 @@ async def test_coordinator_communication_error_raises_update_failed(
 
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
+
+
+async def test_coordinator_runtime_error_recovers_automatically(
+    hass, setup_integration, mock_client
+):
+    """When the session cookie expires (RuntimeError), the coordinator re-logs in and retries."""
+    from custom_components.chargepoint.const import DATA_CLIENT, DATA_COORDINATOR
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id][DATA_COORDINATOR]
+
+    # First call raises RuntimeError (session cookie expired); subsequent calls succeed.
+    mock_client.get_account = AsyncMock(
+        side_effect=[
+            RuntimeError("Must login to use ChargePoint API"),
+        ]
+    )
+
+    new_client = make_mock_client()
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        new_callable=AsyncMock,
+        return_value=new_client,
+    ):
+        data = await coordinator._async_update_data()
+
+    assert data is not None
+    assert hass.data[DOMAIN][setup_integration.entry_id][DATA_CLIENT] is new_client
+    mock_client.close.assert_awaited_once()
+
+
+async def test_coordinator_runtime_error_relogin_invalid_session_raises_auth_failed(
+    hass, setup_integration, mock_client
+):
+    """When re-login after session expiry fails with InvalidSession, ConfigEntryAuthFailed is raised."""
+    from custom_components.chargepoint.const import DATA_COORDINATOR
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id][DATA_COORDINATOR]
+    mock_client.get_account = AsyncMock(
+        side_effect=RuntimeError("Must login to use ChargePoint API")
+    )
+
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        side_effect=make_invalid_session(),
+    ):
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+
+
+async def test_coordinator_runtime_error_relogin_communication_error_raises_update_failed(
+    hass, setup_integration, mock_client
+):
+    """When re-login after session expiry fails with a network error, UpdateFailed is raised."""
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    from custom_components.chargepoint.const import DATA_COORDINATOR
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id][DATA_COORDINATOR]
+    mock_client.get_account = AsyncMock(
+        side_effect=RuntimeError("Must login to use ChargePoint API")
+    )
+
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        side_effect=make_communication_error(),
+    ):
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
 
 
 async def test_coordinator_charger_schedule_error_does_not_fail_update(


### PR DESCRIPTION
Two root-cause fixes for the recurring "Must login to use ChargePoint API"
error reported in issue #81:

1. Stop passing the shared HA aiohttp session to ChargePoint.create().
   The library now owns its own private session and cookie jar, giving it
   full control over coulomb_sess cookie lifecycle (including the 10-year
   max-age override in _set_coulomb_token).

2. Handle the RuntimeError that the library raises when the session cookie
   has expired. The coordinator now attempts an automatic re-login using
   the stored coulomb_token before falling back to ConfigEntryAuthFailed.
   Previously this error was completely unhandled, causing a silent
   "unexpected error" with no recovery path.

Three new tests cover the RuntimeError recovery scenarios.

https://github.com/mbillow/ha-chargepoint/issues/81