### PR TITLE
Add account-level Stop Public Charging button (closes #87)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,14 +40,16 @@ tests/
 
 ### Python Version
 
-Check `.github/workflows/combined.yaml` for the canonical Python version (`python-version:` under the `lint-and-test` job). There is no `.python-version` file.
+The canonical Python version is defined in `.github/workflows/combined.yaml` under `python-version:` in the `lint-and-test` job. There is no `.python-version` file — always read the workflow to get the current value before doing anything else.
+
+**Always use the exact version from the workflow.** Do not use a generic `python3` invocation — it may resolve to a different version. For example, if the workflow specifies `3.13`, use `python3.13`.
 
 ### Installing Dependencies
 
-Create a virtual environment first, then install dependencies:
+**Always create a venv with the exact Python version from the workflow before installing anything.** Never install dependencies globally or skip venv creation because packages appear to be available already.
 
 ```bash
-python3 -m venv .venv
+python3.X -m venv .venv   # X = version from combined.yaml
 source .venv/bin/activate
 pip install -r requirements_test.txt
 ```
@@ -56,15 +58,16 @@ This installs all test, lint, type-check, and formatting tools plus `python-char
 
 ### Running Checks
 
-**All checks are run via pre-commit. This is the single source of truth.**
+**All checks are run via pre-commit from within the activated venv. This is the single source of truth.**
 
 ```bash
+source .venv/bin/activate
 pre-commit run --all-files
 ```
 
 This runs in order: `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`, `black`, `flake8`, `isort`, `mypy`, `pyright`, `pytest`.
 
-Do not run tools individually — always use `pre-commit run --all-files`. **Do not commit unless this passes cleanly.**
+Do not run `pytest`, `mypy`, `black`, or any other tool individually — always use `pre-commit run --all-files`. **Do not commit unless this passes cleanly.**
 
 ### Local HA Instance (Optional)
 

--- a/custom_components/chargepoint/button.py
+++ b/custom_components/chargepoint/button.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from python_chargepoint.exceptions import CommunicationError
 
-from . import ChargePointChargerEntity
+from . import ChargePointChargerEntity, ChargePointEntity
 from .const import (
     ACCT_HOME_CRGS,
     CHARGER_SESSION_STATE_IN_USE,
@@ -124,6 +124,54 @@ class ChargePointChargerStopChargingButton(ButtonEntity, ChargePointChargerEntit
         _schedule_charging_update(self.hass, self.coordinator)
 
 
+class ChargePointStopPublicChargingButton(ButtonEntity, ChargePointEntity):
+    """Account-level button for stopping an active public charging session.
+
+    Available whenever the account has an IN_USE session that is not associated
+    with any of the user's home chargers (i.e. a public station session).
+    """
+
+    def __init__(self, client, coordinator) -> None:
+        super().__init__(client, coordinator)
+        self._attr_name = f"{self.account.user.username} Stop Public Charging"
+        self._attr_unique_id = (
+            f"{self.account.user.user_id}_stop_public_charging_session"
+        )
+        self._attr_icon = "mdi:stop"
+
+    @property
+    def _public_session(self):
+        """Return the active session only if it is at a public station."""
+        session = self.session
+        if not session:
+            return None
+        home_charger_ids = set(self.coordinator.data.get(ACCT_HOME_CRGS, {}).keys())
+        if session.device_id in home_charger_ids:
+            return None
+        return session
+
+    @property
+    def available(self) -> bool:
+        return (
+            super().available
+            and self._public_session is not None
+            and self._public_session.charging_state.upper()
+            == CHARGER_SESSION_STATE_IN_USE
+        )
+
+    async def async_press(self) -> None:
+        session = self._public_session
+        if not session:
+            raise HomeAssistantError("Cannot stop a session that doesn't exist!")
+        try:
+            _LOGGER.info("Stopping ChargePoint public session: %s", session.session_id)
+            await session.stop()
+        except CommunicationError:
+            _LOGGER.warning(EXCEPTION_WARNING_MSG)
+        await self.coordinator.async_request_refresh()
+        _schedule_charging_update(self.hass, self.coordinator)
+
+
 _RESTART_DESCRIPTION = ChargePointChargerButtonEntityDescription(
     key="restart_charger",
     name_suffix="Restart Charger",
@@ -151,7 +199,7 @@ async def async_setup_entry(
     client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
     coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
 
-    entities = []
+    entities: list[ButtonEntity] = []
     for charger_id in coordinator.data[ACCT_HOME_CRGS].keys():
         entities += [
             ChargePointChargerRestartChargerButton(
@@ -164,5 +212,7 @@ async def async_setup_entry(
                 client, coordinator, _STOP_CHARGING_DESCRIPTION, charger_id
             ),
         ]
+
+    entities.append(ChargePointStopPublicChargingButton(client, coordinator))
 
     async_add_entities(entities)

--- a/custom_components/chargepoint/const.py
+++ b/custom_components/chargepoint/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import Platform
 NAME = "ChargePoint"
 DOMAIN = "chargepoint"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "1.3.1"
+VERSION = "1.4.0"
 ATTRIBUTION = "Data provided by https://www.chargepoint.com"
 ISSUE_URL = "https://github.com/mbillow/ha-chargepoint/issues"
 

--- a/custom_components/chargepoint/manifest.json
+++ b/custom_components/chargepoint/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
       "python-chargepoint>=2.3.2"
     ],
-  "version": "1.3.1"
+  "version": "1.4.0"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,10 +88,10 @@ def make_mock_charger_config(
     return config
 
 
-def make_mock_session(*, state="IN_USE"):
+def make_mock_session(*, state="IN_USE", device_id=CHARGER_ID):
     session = MagicMock()
     session.session_id = 99999
-    session.device_id = CHARGER_ID
+    session.device_id = device_id
     session.charging_state = state
     session.charging_time = 3_600_000  # 1 hour in milliseconds
     session.power_kw = 7.2
@@ -315,6 +315,18 @@ def mock_client_with_public_station(mock_client):
 
 
 @pytest.fixture
+def mock_client_with_public_session(mock_client):
+    """Mock client with an active IN_USE session at a public station (not a home charger)."""
+    mock_client.get_user_charging_status = AsyncMock(
+        return_value=make_mock_user_charging_status()
+    )
+    mock_client.get_charging_session = AsyncMock(
+        return_value=make_mock_session(device_id=PUBLIC_STATION_ID)
+    )
+    return mock_client
+
+
+@pytest.fixture
 async def setup_integration_with_public_station(
     hass, config_entry_with_public_station, mock_client_with_public_station
 ):
@@ -328,6 +340,22 @@ async def setup_integration_with_public_station(
         await hass.config_entries.async_setup(config_entry_with_public_station.entry_id)
         await hass.async_block_till_done()
     return config_entry_with_public_station
+
+
+@pytest.fixture
+async def setup_integration_with_public_session(
+    hass, config_entry, mock_client_with_public_session
+):
+    """Set up the integration with an active public charging session."""
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        new_callable=AsyncMock,
+        return_value=mock_client_with_public_session,
+    ):
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+    return config_entry
 
 
 @pytest.fixture

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -7,10 +7,13 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import (
     CHARGER_ID,
+    PUBLIC_STATION_ID,
+    USER_ID,
     get_entity_id,
     make_communication_error,
     make_mock_charger_status,
     make_mock_session,
+    make_mock_user_charging_status,
 )
 
 # ---------------------------------------------------------------------------
@@ -227,6 +230,112 @@ async def test_stop_charging_schedules_fast_poll(
 ):
     """Pressing stop should schedule extra refreshes to pick up the cleared session state."""
     entity_id = get_entity_id(hass, "button", f"{CHARGER_ID}_stop_charging_session")
+    with patch(
+        "custom_components.chargepoint.button.async_call_later"
+    ) as mock_call_later:
+        await hass.services.async_call(
+            "button", "press", {"entity_id": entity_id}, blocking=True
+        )
+
+    from custom_components.chargepoint.button import _CHARGING_FAST_POLL_DELAYS
+
+    assert mock_call_later.call_count == len(_CHARGING_FAST_POLL_DELAYS)
+    actual_delays = {call.args[1] for call in mock_call_later.call_args_list}
+    assert actual_delays == set(_CHARGING_FAST_POLL_DELAYS)
+
+
+# ---------------------------------------------------------------------------
+# Stop public charging button (account-level)
+# ---------------------------------------------------------------------------
+
+_PUBLIC_STOP_UID = f"{USER_ID}_stop_public_charging_session"
+
+
+async def test_stop_public_charging_button_exists(hass, setup_integration):
+    """Button is always created regardless of whether public stations are configured."""
+    entity_id = get_entity_id(hass, "button", _PUBLIC_STOP_UID)
+    assert entity_id is not None
+
+
+async def test_stop_public_charging_button_unavailable_when_no_session(
+    hass, setup_integration
+):
+    """Button is unavailable when there is no active session."""
+    entity_id = get_entity_id(hass, "button", _PUBLIC_STOP_UID)
+    assert hass.states.get(entity_id).state == "unavailable"
+
+
+async def test_stop_public_charging_button_unavailable_when_session_at_home_charger(
+    hass, setup_integration_with_session
+):
+    """Button is unavailable when the active session is at a home charger."""
+    entity_id = get_entity_id(hass, "button", _PUBLIC_STOP_UID)
+    assert hass.states.get(entity_id).state == "unavailable"
+
+
+async def test_stop_public_charging_button_available_when_public_session_in_use(
+    hass, setup_integration_with_public_session
+):
+    """Button is available when an IN_USE session is at a public (non-home) station."""
+    entity_id = get_entity_id(hass, "button", _PUBLIC_STOP_UID)
+    assert hass.states.get(entity_id).state != "unavailable"
+
+
+async def test_stop_public_charging_button_unavailable_when_session_not_in_use(
+    hass, config_entry, mock_client
+):
+    """Button is unavailable when the public session state is not IN_USE."""
+    mock_client.get_user_charging_status = AsyncMock(
+        return_value=make_mock_user_charging_status()
+    )
+    mock_client.get_charging_session = AsyncMock(
+        return_value=make_mock_session(
+            state="FULLY_CHARGED", device_id=PUBLIC_STATION_ID
+        )
+    )
+    with patch(
+        "custom_components.chargepoint.ChargePoint.create",
+        new_callable=AsyncMock,
+        return_value=mock_client,
+    ):
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_id = get_entity_id(hass, "button", _PUBLIC_STOP_UID)
+    assert hass.states.get(entity_id).state == "unavailable"
+
+
+async def test_stop_public_charging_button_press(
+    hass, setup_integration_with_public_session, mock_client_with_public_session
+):
+    """Pressing the button calls stop() on the active public session."""
+    entity_id = get_entity_id(hass, "button", _PUBLIC_STOP_UID)
+    await hass.services.async_call(
+        "button", "press", {"entity_id": entity_id}, blocking=True
+    )
+    session = mock_client_with_public_session.get_charging_session.return_value
+    session.stop.assert_awaited_once()
+
+
+async def test_stop_public_charging_button_communication_error_does_not_raise(
+    hass, setup_integration_with_public_session, mock_client_with_public_session
+):
+    """CommunicationError from stop() is logged but does not raise to the user."""
+    session = mock_client_with_public_session.get_charging_session.return_value
+    session.stop = AsyncMock(side_effect=make_communication_error())
+
+    entity_id = get_entity_id(hass, "button", _PUBLIC_STOP_UID)
+    await hass.services.async_call(
+        "button", "press", {"entity_id": entity_id}, blocking=True
+    )
+
+
+async def test_stop_public_charging_button_schedules_fast_poll(
+    hass, setup_integration_with_public_session
+):
+    """Pressing stop schedules extra refreshes to pick up the cleared session state."""
+    entity_id = get_entity_id(hass, "button", _PUBLIC_STOP_UID)
     with patch(
         "custom_components.chargepoint.button.async_call_later"
     ) as mock_call_later:


### PR DESCRIPTION
Adds a new ButtonEntity (`ChargePointStopPublicChargingButton`) at the
account level that allows stopping an active public charging session.
The button becomes available whenever the account has an IN_USE session
whose device_id does not match any of the user's home chargers, making
it mutually exclusive with the per-charger Stop Charging buttons.

Also adds a `device_id` parameter to `make_mock_session` in conftest to
support both home-charger and public-station session scenarios in tests.

https://claude.ai/code/session_01AsuVETAsSzrTtfKj4bRDQT