### PR TITLE
Preserve session data when charging session API calls fail mid-session

### DIFF
--- a/custom_components/chargepoint/__init__.py
+++ b/custom_components/chargepoint/__init__.py
@@ -261,7 +261,9 @@ async def _async_recreate_client(
 
 
 async def _async_coordinator_update(
-    client: ChargePoint, entry: ConfigEntry
+    client: ChargePoint,
+    entry: ConfigEntry,
+    previous_data: Optional[dict] = None,
 ) -> dict[str, Any]:
     """Fetch all ChargePoint data for one coordinator update cycle."""
     data: dict[str, Any] = {
@@ -292,14 +294,19 @@ async def _async_coordinator_update(
                     data[ACCT_SESSION] = crg_session
                 except CommunicationError:
                     _LOGGER.warning(
-                        "Failed to fetch active charging session details, "
-                        "session data will be unavailable this update"
+                        "Failed to fetch active charging session details; "
+                        "retaining last known session data to avoid energy sensor reset"
                     )
+                    if previous_data is not None:
+                        data[ACCT_SESSION] = previous_data.get(ACCT_SESSION)
         except CommunicationError:
             _LOGGER.warning(
-                "Failed to fetch user charging status, "
-                "session data will be unavailable this update"
+                "Failed to fetch user charging status; "
+                "retaining last known session data to avoid energy sensor reset"
             )
+            if previous_data is not None:
+                data[ACCT_CRG_STATUS] = previous_data.get(ACCT_CRG_STATUS)
+                data[ACCT_SESSION] = previous_data.get(ACCT_SESSION)
 
         home_chargers: list = await client.get_home_chargers()
         results = await asyncio.gather(
@@ -371,7 +378,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     async def async_update_data():
         nonlocal client
         try:
-            data = await _async_coordinator_update(client, entry)
+            data = await _async_coordinator_update(client, entry, coordinator.data)
         except RuntimeError:
             # The library raises RuntimeError("Must login to use ChargePoint API")
             # when the coulomb_sess cookie has expired from the aiohttp cookie jar.
@@ -383,7 +390,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             stored_token: str = entry.data.get(CONF_ACCESS_TOKEN) or ""
             client = await _async_recreate_client(username, stored_token, client)
             hass.data[DOMAIN][entry.entry_id][DATA_CLIENT] = client
-            data = await _async_coordinator_update(client, entry)
+            data = await _async_coordinator_update(client, entry, coordinator.data)
 
         current_token = entry.data.get(CONF_ACCESS_TOKEN)
         fresh_token = client.coulomb_token

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -315,6 +315,63 @@ async def test_coordinator_charging_status_error_does_not_fail_update(
     assert CHARGER_ID in data[ACCT_HOME_CRGS]
 
 
+async def test_coordinator_session_fetch_error_preserves_previous_session(
+    hass, setup_integration_with_session, mock_client_with_session
+):
+    """A failed get_charging_session preserves last known session data.
+
+    Energy sensors use TOTAL_INCREASING; returning 0 when the API is flaky
+    causes HA to reset the running total and double-count on the next
+    successful poll.  We must retain the previous session instead.
+    """
+    from custom_components.chargepoint.const import ACCT_SESSION, DATA_COORDINATOR
+
+    coordinator = hass.data[DOMAIN][setup_integration_with_session.entry_id][
+        DATA_COORDINATOR
+    ]
+    previous_session = coordinator.data[ACCT_SESSION]
+    assert previous_session is not None
+
+    mock_client_with_session.get_charging_session = AsyncMock(
+        side_effect=make_communication_error()
+    )
+
+    data = await coordinator._async_update_data()
+
+    assert data[ACCT_SESSION] is previous_session
+
+
+async def test_coordinator_charging_status_error_preserves_previous_session(
+    hass, setup_integration_with_session, mock_client_with_session
+):
+    """A failed get_user_charging_status preserves last known session data.
+
+    Same TOTAL_INCREASING double-count risk as above — preserve both status
+    and session from the previous successful update when the status call fails.
+    """
+    from custom_components.chargepoint.const import (
+        ACCT_CRG_STATUS,
+        ACCT_SESSION,
+        DATA_COORDINATOR,
+    )
+
+    coordinator = hass.data[DOMAIN][setup_integration_with_session.entry_id][
+        DATA_COORDINATOR
+    ]
+    previous_session = coordinator.data[ACCT_SESSION]
+    previous_status = coordinator.data[ACCT_CRG_STATUS]
+    assert previous_session is not None
+
+    mock_client_with_session.get_user_charging_status = AsyncMock(
+        side_effect=make_communication_error()
+    )
+
+    data = await coordinator._async_update_data()
+
+    assert data[ACCT_SESSION] is previous_session
+    assert data[ACCT_CRG_STATUS] is previous_status
+
+
 # ---------------------------------------------------------------------------
 # async_unload_entry
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When get_charging_session or get_user_charging_status raises a
CommunicationError during an active session, ACCT_SESSION was being
reset to None. The session_energy_kwh sensors (state_class=TOTAL_INCREASING)
then reported 0, causing HA's energy dashboard to treat the next real
value as newly-consumed energy — doubling the session total.

Now _async_coordinator_update accepts the previous coordinator data and
falls back to it for ACCT_SESSION (and ACCT_CRG_STATUS) on failure,
so the energy sensors hold their last known value instead of dropping to 0.

Closes #92

https://claude.ai/code/session_01WAgCa8XH8damQHcnXnPHZ6